### PR TITLE
Replace: Update methods to check block meta when comparing blocks.

### DIFF
--- a/src/BlockHorizons/BlockSniper/brush/types/ReplaceType.php
+++ b/src/BlockHorizons/BlockSniper/brush/types/ReplaceType.php
@@ -31,7 +31,7 @@ class ReplaceType extends BaseType {
 		foreach($this->blocks as $block) {
 			$randomBlock = $this->brushBlocks[array_rand($this->brushBlocks)];
 			foreach($this->obsolete as $obsolete) {
-				if($block->getId() === $obsolete->getId()) {
+				if($block->getId() === $obsolete->getId() and $block->getDamage() === $obsolete->getDamage()) {
 					$undoBlocks[] = $block;
 					$this->putBlock($block, $randomBlock->getId(), $randomBlock->getDamage());
 				}
@@ -44,7 +44,7 @@ class ReplaceType extends BaseType {
 		foreach($this->blocks as $block) {
 			$randomBlock = $this->brushBlocks[array_rand($this->brushBlocks)];
 			foreach($this->obsolete as $obsolete) {
-				if($block->getId() === $obsolete->getId()) {
+				if($block->getId() === $obsolete->getId() and $block->getDamage() === $obsolete->getDamage()) {
 					$this->putBlock($block, $randomBlock->getId(), $randomBlock->getDamage());
 				}
 			}


### PR DESCRIPTION
This fixes #94 by adding checks to block damage.