### PR TITLE
Removed API 3.2.0 from plugin.yml

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 {
   "name": "BlockSniper",
   "version": "3.2.0",
-  "api": ["3.2.0", "4.0.0"],
+  "api": ["4.0.0"],
   "author": "BlockHorizons",
   "authors": [
     "Sandertv (@Sandertv)",


### PR DESCRIPTION
The `API-4.0.0` branch is incompatible with API `3.2.0` due to backwards-incompatible changes introduced.
This pull request removes the old API version from `plugin.yml` so the plugin won't load on old servers