### PR TITLE
Fix artifact_url that previously was messing up the .phar

### DIFF
--- a/src/BlockHorizons/BlockSniper/tasks/UpdateNotifyTask.php
+++ b/src/BlockHorizons/BlockSniper/tasks/UpdateNotifyTask.php
@@ -46,6 +46,7 @@ class UpdateNotifyTask extends AsyncTask{
 		if($highestVersion === Loader::VERSION){
 			return;
 		}
+		$artifactUrl = $artifactUrl . "/BlockSniper_" . $highestVersion . ".phar";
 		$loader->getLogger()->info(vsprintf("Version %s has been released for API %s. Download the new release at %s",
 											[$highestVersion, $api, $artifactUrl]));
 	}


### PR DESCRIPTION
# Description

Artifact URL in the `UpdateNotifyTask` previously downloaded the required `.phar` file but it needed to be renamed and thus could not be used. This PR solves that issue.